### PR TITLE
Make test outcome more precise?

### DIFF
--- a/tests/Radiation/MeterRadiationTest.php
+++ b/tests/Radiation/MeterRadiationTest.php
@@ -21,7 +21,7 @@ class MeterRadiationTest extends TestCase
             ),
             new CarbonImmutable('2021-11-01 11:00:00'),
             111,
-            107.6038497322];
+            107.6038497321954];
 
         yield 'East facing 80 degrees should return 18 W/m2' => [
             new MeterFacts(
@@ -32,7 +32,7 @@ class MeterRadiationTest extends TestCase
             ),
             new CarbonImmutable('2021-11-01 11:00:00'),
             111,
-            18.049368565163];
+            18.049368565163366];
 
         yield 'West facing 40 degrees should return 26 W/m2' => [
             new MeterFacts(
@@ -43,7 +43,7 @@ class MeterRadiationTest extends TestCase
             ),
             new CarbonImmutable('2021-11-01 11:00:00'),
             111,
-            26.35906520119];
+            26.35906520119014];
     }
 
     /** @dataProvider MeterRadiationDataProvider */

--- a/tests/Time/PeriodTest.php
+++ b/tests/Time/PeriodTest.php
@@ -116,7 +116,7 @@ class PeriodTest extends TestCase
             CarbonImmutable::parse('1988-08-20'),
             CarbonImmutable::parse('2019-07-15')
         );
-        $this->assertEquals(1612.2857142857, $period->inWeeks());
+        $this->assertEquals(1612.2857142857142, $period->inWeeks());
         $this->assertEquals(11286, $period->inDays());
         $this->assertEquals(270864, $period->inHours());
         $this->assertEquals(16251840, $period->inMinutes());


### PR DESCRIPTION
Somehow tests started failing due to the outcome being more precise. No idea why, not sure if it's worth finding out...