### PR TITLE
Upgrade/support carbon 30 drop php LT 81

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: [ '7.4', '8.0','8.1','8.2','8.3' ]
+        php-version:
+          - "8.1"
+          - "8.2"
+          - "8.3"
+        dependency-versions:
+          - "lowest"
+          - "highest"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -16,17 +22,12 @@ jobs:
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - name: Install Composer dependencies
-        run: composer install --no-progress --prefer-dist --optimize-autoloader
-      - name: Cache composer dependencies
-        uses: actions/cache@v2
+
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@v2
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
+          dependency-versions: ${{ matrix.dependency-versions }}
+
       - name: Run phpunit
         run: ./vendor/bin/phpunit
   test_success:

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     }
   ],
   "require": {
-    "php": "^7.4|^8.0",
-    "nesbot/carbon": "^2.0"
+    "php": "^8.1",
+    "nesbot/carbon": "^2.64|^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0|^8.0",

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,9 @@
     "nesbot/carbon": "^2.64|^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0|^8.0",
-    "ext-json": "*"
+    "phpunit/phpunit": "^7.0|>=8.5.23",
+    "ext-json": "*",
+    "larapack/dd": "^1.1"
   },
   "autoload": {
     "psr-4": {

--- a/tests/Measurement/EnergyTest.php
+++ b/tests/Measurement/EnergyTest.php
@@ -14,7 +14,7 @@ class EnergyTest extends TestCase
         $this->assertInstanceOf(FormattedMeasurement::class, $energy->format());
     }
 
-    public function formatDataProvider(): array
+    public static function formatDataProvider(): array
     {
         return [
             [$kwh = 1, 'Wh'],
@@ -50,7 +50,7 @@ class EnergyTest extends TestCase
         $this->assertEquals($kwh / 1000 / 1000 / 1000, $energy->asTwh());
     }
 
-    public function formatsToTheRightValueAndUnitDataProvider(): array
+    public static function formatsToTheRightValueAndUnitDataProvider(): array
     {
         return [
             [54321, '54.32 MWh'],

--- a/tests/Measurement/MassTest.php
+++ b/tests/Measurement/MassTest.php
@@ -14,7 +14,7 @@ class MassTest extends TestCase
         $this->assertInstanceOf(FormattedMeasurement::class, $mass->format());
     }
 
-    public function formatDataProvider(): array
+    public static function formatDataProvider(): array
     {
         return [
             [$kg = 1, 'g'],
@@ -50,7 +50,7 @@ class MassTest extends TestCase
         $this->assertEquals($kg / 1000 / 1000 / 1000 / 1000, $mass->asGt());
     }
 
-    public function formatsToTheRightValueAndUnitDataProvider(): array
+    public static function formatsToTheRightValueAndUnitDataProvider(): array
     {
         return [
             [5432, '5432 kg'],

--- a/tests/Radiation/MeterRadiationTest.php
+++ b/tests/Radiation/MeterRadiationTest.php
@@ -10,7 +10,7 @@ use Sundata\Utilities\Radiation\MeterFacts;
 
 class MeterRadiationTest extends TestCase
 {
-    public function MeterRadiationDataProvider(): Generator
+    public static function MeterRadiationDataProvider(): Generator
     {
         yield 'South facing 80 degrees should return 107 W/m2' => [
             new MeterFacts(

--- a/tests/Radiation/RadiationInPeriodTest.php
+++ b/tests/Radiation/RadiationInPeriodTest.php
@@ -11,7 +11,7 @@ use Sundata\Utilities\Time\Period;
 
 class RadiationInPeriodTest extends TestCase
 {
-    public function RadiationInPeriodDataProvider(): Generator
+    public static function RadiationInPeriodDataProvider(): Generator
     {
         yield 'Full year, but you forget end-is-exclusive' => [
             '2019-01-01',
@@ -91,7 +91,7 @@ class RadiationInPeriodTest extends TestCase
         ];
     }
 
-    public function sumDataProvider(): Generator
+    public static function sumDataProvider(): Generator
     {
         $expectedDecember = 5385;
         yield 'December' => [
@@ -170,7 +170,7 @@ class RadiationInPeriodTest extends TestCase
         );
     }
 
-    function avgRadiationForDayProvider(): Generator
+    static function avgRadiationForDayProvider(): Generator
     {
         yield '1jan' => [1, 166, 1999];
         yield '20 aug' => [Carbon::parse('2011-08-20')->dayOfYear, 1610, 1999];

--- a/tests/String/StringUtilTest.php
+++ b/tests/String/StringUtilTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class StringUtilTest extends TestCase
 {
-    public function rangesExplodeDataProvider()
+    public static function rangesExplodeDataProvider()
     {
         return [ // @formatter:off
             // input ?invalidArg, outcome

--- a/tests/Time/DateRangeTzTest.php
+++ b/tests/Time/DateRangeTzTest.php
@@ -68,7 +68,7 @@ class DateRangeTzTest extends TestCase
         );
     }
 
-    function periodDataProvider(): array
+    static function periodDataProvider(): array
     {
         return [
             ['2022-01-01', 'Europe/Amsterdam', '2022-01-01T00:00:00+01:00', '2022-01-02T00:00:00+01:00'],

--- a/tests/Time/DateSplitterTest.php
+++ b/tests/Time/DateSplitterTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 class DateSplitterTest extends TestCase
 {
 
-    public function hourSplitDataProvider()
+    public static function hourSplitDataProvider()
     {
         return [
 
@@ -54,7 +54,7 @@ class DateSplitterTest extends TestCase
     }
 
 
-    public function daySplitDataProvider(): Generator
+    public static function daySplitDataProvider(): Generator
     {
         yield 'simple' => ['2015-12-27T22:22:00+01:00', '2015-12-29T01:11:00+01:00', [
             ['2015-12-27T22:22:00+01:00', '2015-12-28T00:00:00+01:00'],
@@ -73,7 +73,7 @@ class DateSplitterTest extends TestCase
         $this->assertSplit($start, $end, $expectedPeriodsArray, 'splitInDays', 'splitPeriodInDays');
     }
 
-    public function weekSplitDataProvider()
+    public static function weekSplitDataProvider()
     {
         return [
             ['2015-12-27T00:00:00Z', '2016-01-19T00:00:00Z', [
@@ -100,7 +100,7 @@ class DateSplitterTest extends TestCase
     }
 
 
-    public function monthSplitDataProvider()
+    public static function monthSplitDataProvider()
     {
         return [
             ['2015-11-27T00:00:00Z', '2016-03-29T00:00:00Z', [
@@ -119,7 +119,7 @@ class DateSplitterTest extends TestCase
         $this->assertSplit($start, $end, $expectedPeriodsArray, 'splitInMonths', 'splitPeriodInMonths');
     }
 
-    public function yearSplitDataProvider()
+    public static function yearSplitDataProvider()
     {
         return [
             // Zulu time explicit
@@ -170,7 +170,7 @@ class DateSplitterTest extends TestCase
         $this->assertEquals($expectedPeriods, $period);
     }
 
-    public function split24hDataProvider(): Generator
+    public static function split24hDataProvider(): Generator
     {
         yield 'simple' => ['2015-12-27T22:22:00+01:00', '2015-12-29T01:11:00+01:00', [
             ['2015-12-27T22:22:00+01:00', '2015-12-28T22:22:00+01:00'],

--- a/tests/Time/DateTest.php
+++ b/tests/Time/DateTest.php
@@ -48,7 +48,7 @@ class DateTest extends TestCase
         );
     }
 
-    function isBeforeAndIsAfterDataProvider(): array
+    static function isBeforeAndIsAfterDataProvider(): array
     {
         return [
             ['2021-01-01', '2021-01-02', true, false],

--- a/tests/Time/DateTzTest.php
+++ b/tests/Time/DateTzTest.php
@@ -64,7 +64,7 @@ class DateTzTest extends TestCase
         );
     }
 
-    function isBeforeAndIsAfterDataProvider(): array
+    static function isBeforeAndIsAfterDataProvider(): array
     {
         return [
             ['2021-01-01', '2021-01-02', true, false],

--- a/tests/Time/DstTransitionsTest.php
+++ b/tests/Time/DstTransitionsTest.php
@@ -8,7 +8,7 @@ use Sundata\Utilities\Time\DstTransitions;
 
 class DstTransitionsTest extends TestCase
 {
-    function dataProvider(): array
+    static function dataProvider(): array
     {
         return [
             [2002, '2002-03-31T01:00:00Z', '2002-10-27T01:00:00Z'],

--- a/tests/Time/PeriodOverlapTest.php
+++ b/tests/Time/PeriodOverlapTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class PeriodOverlapTest extends TestCase
 {
 
-    public function periodOverlapDataProvider(): \Generator
+    public static function periodOverlapDataProvider(): \Generator
     {
         yield 'No overlap returns null' => [
             new Period(

--- a/tests/Time/PeriodTest.php
+++ b/tests/Time/PeriodTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class PeriodTest extends TestCase
 {
 
-    public function periodLengthDataProvider(): array
+    public static function periodLengthDataProvider(): array
     {
         //@formatter:off
     return [
@@ -41,7 +41,7 @@ class PeriodTest extends TestCase
         $this->assertEquals($expectedResult, $result);
     }
 
-    public function isInPeriodDataProvider(): array
+    public static function isInPeriodDataProvider(): array
     {
         $defaultStart = '2000-01-01T00:00:00+01:00';
         $defaultEnd = '2000-01-02T00:00:00+01:00';
@@ -69,7 +69,7 @@ class PeriodTest extends TestCase
         $this->assertEquals($expectedResult, $result);
     }
 
-    function dstSplittingProvider(): array
+    static function dstSplittingProvider(): array
     {
         return [
             'normal' => ['2018-01-01', '2019-01-01', [


### PR DESCRIPTION
Laravel 11 now uses Carbon 3. Sd php-utilities is locked to 2.

Yeah, still my go-to package for slicing up periods 😜 📆 🪚

I've added a way to the ci.yml that both the lowest and highest versions of requirements get tested.
This however also results in high and low numbers of phpunit. Resulting in a need for some small tuning for the high versions of phpunit (dataproviders need to be static) and slightly nudging PHPunit to a certain version because of an issue with $GLOBALS. [See this post](https://stackoverflow.com/questions/70455395/phpunit-cannot-acquire-reference-to-globals).

Now the tests run the php matrix with the lowest version of Carbon I found possible and still plausible to use (2.64) and the latest version. [How? See this post](https://tech.osteel.me/posts/a-github-workflow-to-check-the-compatibility-of-your-php-package-with-a-range-of-dependency-versions)

**Lowest**
![CleanShot 2024-05-15 at 06h51@2x](https://github.com/frittsnl/sundata-php-utilities/assets/724492/583edfb2-8430-40c4-b12d-bec41dd82257)

**Highest**
![CleanShot 2024-05-15 at 06h55@2x](https://github.com/frittsnl/sundata-php-utilities/assets/724492/10fb418a-4f10-4cb7-a5ae-0cf89cb71c75)

Note: I've removed caching composer from the CI. Tests run super fast and thinking it could only lead to issues which would be hard to see when installing highest/lowest versions.